### PR TITLE
Add check for debugger statement.

### DIFF
--- a/hooks/pre-commit
+++ b/hooks/pre-commit
@@ -10,7 +10,7 @@ fi
 # Redirect output to stderr.
 exec 1>&2
 
-keywords=(binding.pry throw console.log)
+keywords=(binding.pry throw console.log debugger)
 keywords_for_grep=$(printf "|%s" "${keywords[@]}")
 keywords_for_grep=${keywords_for_grep:1}
 files_changed=`git diff-index --name-only HEAD --`


### PR DESCRIPTION
Hi,

Nice project, it would be nice if it will support a flag to force push changes. I'm sometimes debugging using `raise myobject.inspect` or `puts myobject.inspect` and I want to be able to filter by `raise` or `puts`, but sometimes I really need to commit `raise MyError` or something using `puts`.
